### PR TITLE
Bugfix GPS plugin coordinate

### DIFF
--- a/uuv_sensor_plugins/uuv_sensor_ros_plugins/src/GPSROSPlugin.cc
+++ b/uuv_sensor_plugins/uuv_sensor_ros_plugins/src/GPSROSPlugin.cc
@@ -75,8 +75,8 @@ bool GPSROSPlugin::OnUpdateGPS()
   this->gpsMessage.header.stamp.nsec = currentTime.nsec;
 
   // Copy the output of Gazebo's GPS sensor into a NavSatFix message
-  this->gpsMessage.latitude = -this->gazeboGPSSensor->Latitude().Degree();
-  this->gpsMessage.longitude = -this->gazeboGPSSensor->Longitude().Degree();
+  this->gpsMessage.latitude = this->gazeboGPSSensor->Latitude().Degree();
+  this->gpsMessage.longitude = this->gazeboGPSSensor->Longitude().Degree();
   this->gpsMessage.altitude = this->gazeboGPSSensor->Altitude();
 
   this->rosSensorOutputPub.publish(this->gpsMessage);

--- a/uuv_world_plugins/uuv_world_ros_plugins/src/SphericalCoordinatesROSInterfacePlugin.cc
+++ b/uuv_world_plugins/uuv_world_ros_plugins/src/SphericalCoordinatesROSInterfacePlugin.cc
@@ -137,7 +137,7 @@ bool SphericalCoordinatesROSInterfacePlugin::TransformFromSphericalCoord(
 #endif
   // The minus signs on X and Y come from the fact that
   // Gazebo outputs the cartesian coordinates in the
-  // -E/-U/N format instead of E/N/U format
+  // -E/-N/U format instead of E/N/U format
   // The issue is mentioned in:
   // https://github.com/uuvsimulator/uuv_simulator/issues/390 
   _res.output.x = -cartVec.X();

--- a/uuv_world_plugins/uuv_world_ros_plugins/src/SphericalCoordinatesROSInterfacePlugin.cc
+++ b/uuv_world_plugins/uuv_world_ros_plugins/src/SphericalCoordinatesROSInterfacePlugin.cc
@@ -135,8 +135,13 @@ bool SphericalCoordinatesROSInterfacePlugin::TransformFromSphericalCoord(
   ignition::math::Vector3d cartVec =
     this->world->GetSphericalCoordinates()->LocalFromSpherical(scVec);
 #endif
-  _res.output.x = cartVec.X();
-  _res.output.y = cartVec.Y();
+  // The minus signs on X and Y come from the fact that
+  // Gazebo outputs the cartesian coordinates in the
+  // -E/-U/N format instead of E/N/U format
+  // The issue is mentioned in:
+  // https://github.com/uuvsimulator/uuv_simulator/issues/390 
+  _res.output.x = -cartVec.X();
+  _res.output.y = -cartVec.Y();
   _res.output.z = cartVec.Z();
   return true;
 }


### PR DESCRIPTION
According to https://github.com/uuvsimulator/uuv_simulator/issues/390, Gazebo is publishing -East -North Up instead of East North Up.

UUV Simulator handled this case by adding a minus sign to lat / lon in the GPS ROS Plugin.

However, this approach makes the creation of a .world confusing, as the origin of the world must have negative lat / lon.

The temporary solution (until Gazebo fixes its frame output according to https://github.com/gazebosim/gazebo-classic/issues/2022#issuecomment-2132414592) is:

```
<!-- In the .world file -->
<spherical_coordinates>
      <!-- currently gazebo has a bug: instead of outputing lat, long, altitude in ENU
      (x = East, y = North and z = Up) as the default configurations, it's outputting (-E)(-N)U,
      therefore we rotate the default frame 180 so that it would go back to ENU -->
      <heading_deg>180</heading_deg>
  </spherical_coordinates>
```